### PR TITLE
Update the average rating of the book

### DIFF
--- a/backend/app/api/routes/books.py
+++ b/backend/app/api/routes/books.py
@@ -322,8 +322,14 @@ def create_comment_rating(
                 VALUES (%s, %s, %s, %s)
             """
             cursor.execute(query_insert, (user_id, id, comment, rating))
-            conexion.commit()
 
+            query_avg_rating = "SELECT AVG(Rating) FROM CommentRatingPerBook WHERE IdBook = %s"
+            cursor.execute(query_avg_rating, (id,))
+            avg_rating = cursor.fetchone()[0]
+
+            query_update_book = "UPDATE Books SET Rating = %s WHERE IdBook = %s"
+            cursor.execute(query_update_book, (avg_rating, id))
+            conexion.commit()
             return {"message": "Comment and rating successfully added."}
 
     except mysql.connector.Error as e:


### PR DESCRIPTION
**Description**
This PR introduces a modification to the create_comment_rating endpoint to update the average rating of a book.

**Changes**
After adding a rating, it calculates the average rating of the book from the CommentRatingPerBook table and updates the Rating column in the Books table with the new average
Implemented search logic to match the keyword against both titles and authors.
![image](https://github.com/user-attachments/assets/e9f5d107-138e-4874-9319-d7ac70bb1227)
![image](https://github.com/user-attachments/assets/89e1d325-8c49-4b80-bf4c-8a923a495d27)
