### PR TITLE
Delete comment

### DIFF
--- a/backend/app/api/routes/books.py
+++ b/backend/app/api/routes/books.py
@@ -517,3 +517,52 @@ def delete_book(book_id: int) -> Any:
             conexion.close()
             print("Conexión cerrada")
 
+@router.delete("/CommentRatingPerBook/{comment_id}")
+def delete_comment(comment_id: int):
+    try:
+        # Conexión a la base de datos
+        conexion = mysql.connector.connect(
+            host=host,
+            user=user,
+            password=password,
+            database=database,
+            port=3306
+        )
+
+        if conexion.is_connected():
+            cursor = conexion.cursor()
+
+            # Verificar que el comentario existe
+            query_check_comment = "SELECT IdBook FROM CommentRatingPerBook WHERE IdCommentRating = %s"
+            cursor.execute(query_check_comment, (comment_id,))
+            result = cursor.fetchone()
+            if not result:
+                raise HTTPException(status_code=404, detail="Comment not found.")
+
+            # Obtener el IdBook del comentario
+            id_book = result[0]
+
+            # Eliminar el comentario
+            query_delete = "DELETE FROM CommentRatingPerBook WHERE IdCommentRating = %s"
+            cursor.execute(query_delete, (comment_id,))
+
+            # Recalcular el promedio de calificación
+            query_avg_rating = "SELECT AVG(Rating) FROM CommentRatingPerBook WHERE IdBook = %s"
+            cursor.execute(query_avg_rating, (id_book,))
+            avg_rating = cursor.fetchone()[0] or 0  # Si no hay calificaciones, promedio es 0
+
+            # Actualizar el promedio en la tabla de libros
+            query_update_book = "UPDATE Books SET Rating = %s WHERE IdBook = %s"
+            cursor.execute(query_update_book, (avg_rating, id_book))
+
+            conexion.commit()
+            return {"message": "Comment successfully deleted."}
+
+    except mysql.connector.Error as e:
+        print(f"MySQL Error: {e}")
+        raise HTTPException(status_code=500, detail="Database connection error.")
+
+    finally:
+        if conexion.is_connected():
+            cursor.close()
+            conexion.close()


### PR DESCRIPTION
**Description**
This PR introduces the delete_comment endpoint to delete a comment and the rating of a book.

**Changes**
Added a new delete endpoint at /CommentRatingPerBook/{comment_id} for deleting a comment and its associated rating from a book.
The endpoint verifies the existence of the comment, deletes it, and recalculates the average rating for the associated book.
Updates the Books table with the new average rating after deletion.

![image](https://github.com/user-attachments/assets/dd422b2a-7a40-4cbf-a52e-23133fd19220)
![image](https://github.com/user-attachments/assets/809d0ec1-a98e-4fa8-82ca-08d5e24def2c)
